### PR TITLE
Added the gitignore folder with node_modules in it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules


### PR DESCRIPTION
Node_modules were being tracked by git. Node modules should not be public. So I added the gitignore folder and added node_modules in it. 
Now node_modules are not being tracked by git.